### PR TITLE
Fix maxDuration Error

### DIFF
--- a/app/api/cron/route.ts
+++ b/app/api/cron/route.ts
@@ -6,7 +6,7 @@ import Product from "@/lib/models/product.model";
 import { scrapeAmazonProduct } from "@/lib/scraper";
 import { generateEmailBody, sendEmail } from "@/lib/nodemailer";
 
-export const maxDuration = 300; // This function can run for a maximum of 300 seconds
+export const maxDuration = 10; // This function can run for a maximum of 300 seconds
 export const dynamic = "force-dynamic";
 export const revalidate = 0;
 


### PR DESCRIPTION
This pull request addresses an error related to the maxDuration value in the Serverless Function configuration. The maxDuration value was outside the allowed range for the "hobby" plan, and this fix adjusts it to a valid value within the range.
